### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "An interface for working with the Nadeo API"
-repository = "https://www.github.com/TgZ39/nadeo-api"
+repository = "https://github.com/TgZ39/nadeo-api"
 keywords = ["nadeo", "nadeo-api-client", "trackmania"]
 categories = ["api-bindings"]
 


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/tgz39